### PR TITLE
Enforce turn caps and remove pressure mechanic

### DIFF
--- a/Milestone 2/gamestate.lua
+++ b/Milestone 2/gamestate.lua
@@ -1,8 +1,8 @@
 local Gamestate = {
   phase = "MAIN",
   turn  = 1,
-    playedHands = {},           -- e.g., { ["Pair"]=true }
-  limits = { joker_played_this_turn = false }, -- scaffold for 3.2
+  playedHands = {},           -- e.g., { ["Pair"] = true }
+  limits = { discard_used = false }, -- per-turn discard flag
   meta   = { run_id = 1 }     -- placeholder; increments per restart if desired
 }
 
@@ -10,8 +10,9 @@ function Gamestate:reset()
   self.phase = "MAIN"
   self.turn  = 1
   self.playedHands = {}
-  self.limits = { joker_played_this_turn = false }
+  self.limits = { discard_used = false }
   self.meta = self.meta or { run_id = 1 }
 end
 
 return Gamestate
+

--- a/Milestone 2/saveload.lua
+++ b/Milestone 2/saveload.lua
@@ -1,0 +1,114 @@
+-- saveload.lua
+-- Helper routines to snapshot and restore game state.
+
+local M = {}
+
+local function copy_hand(hand)
+  local out = {}
+  for i = 1, #hand do
+    out[i] = { suit = hand[i].suit, rank = hand[i].rank }
+  end
+  return out
+end
+
+function M.build_state(deck, hand, GS, S, UI)
+  local deckState = deck:getState()
+  local handCopy = copy_hand(hand)
+
+  local gs = {
+    phase = GS.phase,
+    current_attack = (S and S.combat and S.combat.current_attack) or nil,
+    overlay = (UI and UI.overlay and UI.overlay.kind) or nil,
+    turn  = GS.turn,
+    playedHands = {},
+    limits = {
+      discard_used = (GS.limits and GS.limits.discard_used) or false
+    },
+    meta   = GS.meta
+  }
+  for k,v in pairs(GS.playedHands) do gs.playedHands[k] = v and true or nil end
+
+  local jokerState
+  if S.jokers then
+    jokerState = {
+      pool = {},
+      hand = {},
+      played_pile = {},
+      used_this_turn = S.jokers.used_this_turn
+    }
+    for i,id in ipairs(S.jokers.pool or {}) do jokerState.pool[i] = id end
+    for i,id in ipairs(S.jokers.hand or {}) do jokerState.hand[i] = id end
+    for i,id in ipairs(S.jokers.played_pile or {}) do jokerState.played_pile[i] = id end
+  end
+
+  local scoring
+  if S.meta then
+    scoring = {}
+    for k,v in pairs(S.meta) do scoring[k] = v end
+  end
+
+  return {
+    deck   = deckState,
+    hand   = handCopy,
+    gs     = gs,
+    jokers = jokerState,
+    scoring = scoring,
+  }
+end
+
+function M.apply_state(state, deck, GS, S, UI, Scoring, Jokers)
+  if deck and deck.loadState and state.deck then
+    deck:loadState(state.deck)
+  end
+
+  local hand = {}
+  for i = 1, #(state.hand or {}) do
+    local c = state.hand[i]
+    hand[i] = { suit = c.suit, rank = c.rank }
+  end
+
+  GS.phase = (state.gs and state.gs.phase) or "MAIN"
+  GS.turn  = (state.gs and state.gs.turn)  or 1
+  GS.playedHands = {}
+  if state.gs and state.gs.playedHands then
+    for k,v in pairs(state.gs.playedHands) do GS.playedHands[k] = v and true or nil end
+  end
+  GS.limits = state.gs and state.gs.limits or { discard_used = false }
+  if state.gs and state.gs.overlay then
+    local k = state.gs.overlay
+    UI.overlay = { kind = k, message = (k == "win") and "You Win!" or "Threshold completed" }
+    GS.phase = "THRESHOLD"
+  else
+    UI.overlay = nil
+  end
+  GS.meta   = state.gs and state.gs.meta or { run_id = 1 }
+
+  S.combat = S.combat or {}
+  S.combat.current_attack = state.gs and state.gs.current_attack or S.combat.current_attack
+
+  if state.scoring then
+    S.meta = {}
+    for k,v in pairs(state.scoring) do S.meta[k] = v end
+  else
+    S.meta = nil
+  end
+  if Scoring then Scoring.init(S) end
+
+  if Jokers then
+    Jokers.init(S, love and love.math or math)
+    if state.jokers then
+      S.jokers.pool = {}
+      S.jokers.hand = {}
+      S.jokers.played_pile = {}
+      for i,id in ipairs(state.jokers.pool or {}) do S.jokers.pool[i] = id end
+      for i,id in ipairs(state.jokers.hand or {}) do S.jokers.hand[i] = id end
+      for i,id in ipairs(state.jokers.played_pile or {}) do S.jokers.played_pile[i] = id end
+      S.jokers.used_this_turn = state.jokers.used_this_turn
+    end
+  end
+
+  return hand
+end
+
+return M
+

--- a/Milestone 2/scoring.lua
+++ b/Milestone 2/scoring.lua
@@ -21,8 +21,6 @@ function M.init(S)
   S.meta = S.meta or {}
   if S.meta.threshold == nil then S.meta.threshold = 1 end
   S.meta.turns = S.meta.turns or 0
-  S.meta.pressure_level = S.meta.pressure_level or 0
-  S.meta.turns_since_pressure = S.meta.turns_since_pressure or 0
   if S.meta.score == nil then S.meta.score = 0 end
   if S.meta.punish_level == nil then S.meta.punish_level = 0 end -- +1 every 30 moves (hook later)
 end
@@ -69,12 +67,6 @@ end
 function M.apply_penalty(S, hand_name)
   local t = clamp_threshold(S.meta.threshold)
   local pts = penalty_for_threshold(t, hand_name)
-  -- Pressure scaling applies only from T4+
-  if (t >= 4) and S and S.meta and (S.meta.pressure_level or 0) > 0 then
-    local lvl = S.meta.pressure_level or 0
-    local mult = (2.25) ^ lvl
-    pts = math.ceil(pts * mult)
-  end
   S.meta.score = (S.meta.score or 0) - pts
   return pts
 end
@@ -100,22 +92,9 @@ function M.reset_for_next_threshold(S)
   S.meta.score = 0
 end
 
-  -- === Pressure Meter (every 30 turns) ===
-  function M.on_turn_advanced(S)
-    if not S or not S.meta then return end
-    S.meta.turns = (S.meta.turns or 0) + 1
-    S.meta.turns_since_pressure = (S.meta.turns_since_pressure or 0) + 1
-    while S.meta.turns_since_pressure >= 30 do
-      S.meta.turns_since_pressure = S.meta.turns_since_pressure - 30
-      S.meta.pressure_level = (S.meta.pressure_level or 0) + 1
-    end
-  end
+function M.on_turn_advanced(S)
+  if not S or not S.meta then return end
+  S.meta.turns = (S.meta.turns or 0) + 1
+end
 
-  function M.pressure_next_in(S)
-    if not S or not S.meta then return 30 end
-    local r = 30 - (S.meta.turns_since_pressure or 0)
-    if r <= 0 then r = 30 end
-    return r
-  end
-
-  return M
+return M

--- a/Milestone 2/tests.lua
+++ b/Milestone 2/tests.lua
@@ -1,0 +1,93 @@
+-- tests.lua
+-- Basic automated checks for Jokers Gambit
+
+love = { math = { random = math.random } }
+
+local Deck = require("deck")
+local Jokers = require("jokers")
+local Attacks = require("attacks")
+local SaveLoad = require("saveload")
+local Scoring = require("scoring")
+local GS = require("gamestate")
+
+local function deep_eq(a, b)
+  if type(a) ~= type(b) then return false end
+  if type(a) ~= "table" then return a == b end
+  for k,v in pairs(a) do if not deep_eq(v, b[k]) then return false end end
+  for k,v in pairs(b) do if not deep_eq(v, a[k]) then return false end end
+  return true
+end
+
+-- Turn flow: joker use capped at 1
+do
+  local S = {}
+  Jokers.init(S, love.math)
+  Jokers.gain_from_pool(S, 2, love.math)
+  assert(#S.jokers.hand >= 2, "need two jokers for test")
+  local r1 = Jokers.use(S, 1, {})
+  assert(r1.ok, "first joker should succeed")
+  local r2 = Jokers.use(S, 1, {})
+  assert(not r2.ok, "second joker should be blocked")
+end
+print("Turn flow test: passed")
+
+-- Attack scaling probabilities snapshot
+do
+  local expected = {
+    [1] = { ["High Card"]=21,["Pair"]=18,["Two Pair"]=16,["Three of a Kind"]=14,["Flush"]=12,["Straight"]=8,["Full House"]=7,["Four of a Kind"]=4 },
+    [2] = { ["High Card"]=16,["Pair"]=16,["Two Pair"]=15,["Three of a Kind"]=14,["Flush"]=12,["Straight"]=10,["Full House"]=10,["Four of a Kind"]=7 },
+    [3] = { ["High Card"]=12,["Pair"]=14,["Two Pair"]=14,["Three of a Kind"]=14,["Flush"]=14,["Straight"]=12,["Full House"]=12,["Four of a Kind"]=8 },
+    [4] = { ["High Card"]=10,["Pair"]=12,["Two Pair"]=12,["Three of a Kind"]=14,["Flush"]=14,["Straight"]=12,["Full House"]=14,["Four of a Kind"]=12 },
+    [5] = { ["High Card"]=8,["Pair"]=10,["Two Pair"]=12,["Three of a Kind"]=14,["Flush"]=14,["Straight"]=14,["Full House"]=14,["Four of a Kind"]=14 },
+  }
+  for t=1,5 do
+    local probs = Attacks.probs_for_threshold(t)
+    assert(deep_eq(probs, expected[t]), "Attack table mismatch at T"..t)
+  end
+end
+print("Attack scaling test: passed")
+
+-- Save/Load round trip
+do
+  local deck = Deck.new(1)
+  GS:reset()
+  local S = {}
+  Scoring.init(S)
+  Jokers.init(S, love.math)
+  Jokers.gain_from_pool(S, 2, love.math)
+  local hand = deck:draw(5)
+  S.meta.score = 42
+  S.meta.threshold = 2
+  GS.playedHands["Pair"] = true
+  deck:discardCards({deck.cards[#deck.cards]})
+  Attacks.announce(S, love.math)
+  GS.turn = 3
+  GS.limits.discard_used = true
+  local UI = {}
+
+  local saved = SaveLoad.build_state(deck, hand, GS, S, UI)
+
+  -- mutate everything
+  deck = Deck.new(1)
+  hand = deck:draw(3)
+  GS:reset()
+  S.meta = {}
+  S.jokers = nil
+  UI = {}
+
+  hand = SaveLoad.apply_state(saved, deck, GS, S, UI, Scoring, Jokers)
+
+  assert(S.meta.score == 42, "score mismatch")
+  assert(S.meta.threshold == 2, "threshold mismatch")
+  assert(GS.turn == 3, "turn mismatch")
+  assert(GS.playedHands["Pair"], "played hand lost")
+  assert(GS.limits.discard_used == true, "discard flag lost")
+  assert(#deck.discard == 1, "discard pile mismatch")
+  assert(S.combat.current_attack == saved.gs.current_attack, "attack mismatch")
+  assert(#S.jokers.hand == #saved.jokers.hand, "joker hand mismatch")
+  assert(#hand == #saved.hand, "hand size mismatch")
+end
+print("Save/Load round trip test: passed")
+
+print("All tests passed.")
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Jokers Gambit Updates
+
+## Changes
+- Enforced per-turn limits for joker use and discarding with clear messages.
+- Save/Load now persists score, threshold, jokers, hand, played hands, discard pile, attack target and turn count.
+- Removed legacy scaling mechanic and all related code/UI.
+- Extracted save/load helpers to `saveload.lua` and added basic automated tests.
+
+## Running
+Ensure Lua is installed. To execute tests:
+
+```bash
+cd "Milestone 2"
+lua tests.lua
+```
+
+Run the game with Love2D as usual:
+
+```bash
+love "Milestone 2"
+```
+


### PR DESCRIPTION
## Summary
- limit joker and discard actions to once per turn with user feedback
- persist full game state via reusable save/load helpers
- drop legacy pressure mechanic and update scoring
- add smoke tests and documentation

## Testing
- `lua tests.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09ff273808322a8008acbae60e17a